### PR TITLE
Dockefile is now multistage build for smaller final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# always nice to pin as precisely as possible
-FROM python:3.13.1-slim-bookworm
+# --- Base Stage: Install Dependencies ---
+FROM python:3.13.1-slim-bookworm AS base
 
 ENV PYTHONUNBUFFERED=True
 WORKDIR /app
@@ -7,19 +7,22 @@ WORKDIR /app
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# First we copy just the project definition files
-# so these layers can be cached
+# Copy project definition files for caching
 COPY pyproject.toml uv.lock ./
 
-# install dependencies
+# Install dependencies using uv
 RUN uv sync --frozen
 
-# now copy in all the rest as late as possible
-# and depending on how we're running this, we don't even need
-# to install it, just copy-paste and run
+# --- Final Stage: Build Application Image ---
+FROM python:3.13.1-slim-bookworm AS runner
+
+WORKDIR /app
+
+# Copy the virtual environment from the base stage
+COPY --from=base /app/.venv ./.venv
+
+# Copy application code
 COPY . /app
 
-# if you DO want to install it, do that here
-
-# or however else you bootstrap your app
+# Set the entrypoint
 CMD ["/app/.venv/bin/python", "/app/postmodern/server.py"]


### PR DESCRIPTION
Using a multistage build makes sure we do not carry over build dependencies into the final produced image, like `uv` itself, as that has a size of ~40MB.

